### PR TITLE
fix: Plugins were output as a list

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -331,7 +331,7 @@ createPluginListsWithPIMT() {
 createPluginCatalogAndPluginsYaml() {
   info "Recreate plugin-catalog"
   touch "${TARGET_PLUGIN_CATALOG}"
-  yq -i '. = { "type": "plugin-catalog", "version": "1", "name": "my-plugin-catalog", "displayName": "My Plugin Catalog", "configurations": [ { "description": "These are Non-CAP plugins", "includePlugins": []}]}' "${TARGET_PLUGIN_CATALOG}"
+  yq -i '. = { "type": "plugin-catalog", "version": "1", "name": "my-plugin-catalog", "displayName": "My Plugin Catalog", "configurations": [ { "description": "These are Non-CAP plugins", "includePlugins": {}}]}' "${TARGET_PLUGIN_CATALOG}"
   for k in $(yq '.plugins[].artifactId' "${TARGET_DIFF}"); do
     v=$(k=$k yq '.plugins[]|select(.artifactId == env(k)).source.version' "${TARGET_DIFF}")
     k="$k" v="$v" yq -i '.configurations[].includePlugins += { env(k): { "version": env(v) }} | style="double" ..' "${TARGET_PLUGIN_CATALOG}"


### PR DESCRIPTION
Changing...

```yaml
type: "plugin-catalog"
version: "1"
name: "my-plugin-catalog"
displayName: "My Plugin Catalog"
configurations:
  - description: "These are Non-CAP plugins"
    includePlugins:
    - ansible:
        version: "174.vfd5323d2b_9d8"
    - cloudbees-prometheus:
        version: "1.2"
    - job-dsl:
        version: "1.83"
```

to the correct format...

```yaml
type: "plugin-catalog"
version: "1"
name: "my-plugin-catalog"
displayName: "My Plugin Catalog"
configurations:
  - description: "These are Non-CAP plugins"
    includePlugins:
      ansible:
        version: "174.vfd5323d2b_9d8"
      cloudbees-prometheus:
        version: "1.2"
      job-dsl:
        version: "1.83"
```