### PR TITLE
fix: revert the catalog version setting

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -642,11 +642,6 @@ createPluginCatalogAndPluginsYaml() {
   yq -i '.configurations[0].includePlugins|=sort_keys(..)|... comments=""' "${TARGET_PLUGIN_CATALOG}"
   cp "${TARGET_PLUGINS_YAML}" "${TARGET_PLUGINS_YAML_SANITIZED}"
 
-  # Add version to catalogs
-  info "Setting version of the plugin catalogs to CI_VERSION for transparency"
-  CI_VERSION=$CI_VERSION yq -i '.version = env(CI_VERSION)' "$TARGET_PLUGIN_CATALOG"
-  CI_VERSION=$CI_VERSION yq -i '.version = env(CI_VERSION)' "$TARGET_PLUGIN_CATALOG_OFFLINE"
-
   # Add metadata comments
   if [ -n "${PLUGIN_YAML_COMMENTS_STYLE}" ]; then
     # Header...

--- a/tests/simple/2.387.3.5/mm/expected-plugin-catalog-offline.yaml
+++ b/tests/simple/2.387.3.5/mm/expected-plugin-catalog-offline.yaml
@@ -1,5 +1,5 @@
 type: "plugin-catalog"
-version: "2.387.3.5"
+version: "1"
 name: "my-plugin-catalog"
 displayName: "My Offline Plugin Catalog"
 configurations:

--- a/tests/simple/2.387.3.5/mm/expected-plugin-catalog.yaml
+++ b/tests/simple/2.387.3.5/mm/expected-plugin-catalog.yaml
@@ -1,5 +1,5 @@
 type: "plugin-catalog"
-version: "2.387.3.5"
+version: "1"
 name: "my-plugin-catalog"
 displayName: "My Plugin Catalog"
 configurations:


### PR DESCRIPTION
We cannot re-purpose the version field because the CasC bundle
validation complains about:

```
WARNING - [CATALOGVAL] - Validate the Plugin Catalog against the CAP configuration -> Parsing Plugin Catalog -> Header -> Version must be '1'.
```
