### PR TITLE
Fix regex for instance type and cve detection

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -188,7 +188,7 @@ prereqs() {
     [ -f "${PLUGIN_CATALOG_OFFLINE_EXEC_HOOK}" ] || die "The exec-hook '${PLUGIN_CATALOG_OFFLINE_EXEC_HOOK}' needs to be a file"
     [ -x "${PLUGIN_CATALOG_OFFLINE_EXEC_HOOK}" ] || die "The exec-hook '${PLUGIN_CATALOG_OFFLINE_EXEC_HOOK}' needs to be executable"
   fi
-  [[ "$CI_TYPE" =~ ^mm|oc|cm|oc-traditional$ ]] || die "CI_TYPE '${CI_TYPE}' not recognised"
+  [[ "$CI_TYPE" =~ ^(mm|oc|cm|oc-traditional)$ ]] || die "CI_TYPE '${CI_TYPE}' not recognised"
 }
 
 setScriptVars() {
@@ -483,7 +483,7 @@ isNotAffectedByCVE() {
       for pattern in $(jq --arg w "$w" 'select(.id == $w).versions[].pattern' "${TARGET_UC_ACTUAL_WARNINGS}"); do
         patternNoQuotes=${pattern//\"/}
         debug "Plugin '$1' - testing version '$pluginVersion' against pattern '$patternNoQuotes' from file '$pWarnings'"
-        if [[ "$pluginVersion" =~ ^$patternNoQuotes$ ]]; then
+        if [[ "$pluginVersion" =~ ^($patternNoQuotes)$ ]]; then
           info "Plugin '$1' - affected by '$w' according to pattern '$patternNoQuotes' from file '$(basename $pWarnings)'"
           return 1
         fi

--- a/tests/multi-files/expected-plugins.yaml
+++ b/tests/multi-files/expected-plugins.yaml
@@ -13,6 +13,6 @@ plugins:
   - id: beer # 3rd lst
   - id: branch-api # cap dep
   - id: git-client # cap lst
-  - id: job-dsl # 3rd lst cve
+  - id: job-dsl # 3rd lst
   - id: mina-sshd-api-common # cap lst dep
   - id: mina-sshd-api-core # cap lst dep


### PR DESCRIPTION
Previously only the first alternative in these regex is tested if it matches the beginning of the test string and the last alternative is tested if it matches the end of the test string. What we want to test is if any of the alternatives match the test string. Hence the added grouping around all alternatives.

This fixes CVE detection for versions that are actually fine as well as incorrect instance types not being rejected (e.g. aaaaocaaa).