### PR TITLE
Fix edge case no plugins after minimal

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -843,11 +843,21 @@ processAllDeps() {
     processDeps "$p"
   done
   # sort processed into files for later
-  printf "%s\n" "${!TARGET_PLUGIN_DEPS_PROCESSED_ARR[@]}" | sort > "${TARGET_PLUGIN_DEPS_PROCESSED}"
-  printf "%s\n" "${!TARGET_PLUGIN_DEPS_PROCESSED_NON_TOP_LEVEL_ARR[@]}" | sort > "${TARGET_PLUGIN_DEPS_PROCESSED_NON_TOP_LEVEL}"
-  echo "plugins:" > "${TARGET_PLUGIN_DEPENDENCY_RESULTS}"
-  printf "  - id: %s\n" "${!TARGET_PLUGIN_DEPENDENCY_RESULTS_ARR[@]}" | sort >> "${TARGET_PLUGIN_DEPENDENCY_RESULTS}"
-  # yq -i '.plugins|=sort_by(.id)|... comments=""' "${TARGET_PLUGIN_DEPENDENCY_RESULTS}"
+  touch \
+    "${TARGET_PLUGIN_DEPS_PROCESSED}" \
+    "${TARGET_PLUGIN_DEPS_PROCESSED_NON_TOP_LEVEL}" \
+    "${TARGET_PLUGIN_DEPENDENCY_RESULTS}"
+  if [ "${TARGET_PLUGIN_DEPS_PROCESSED_ARR[*]}" ]; then
+    printf "%s\n" "${!TARGET_PLUGIN_DEPS_PROCESSED_ARR[@]}" | sort > "${TARGET_PLUGIN_DEPS_PROCESSED}"
+  fi
+  if [ -n "${TARGET_PLUGIN_DEPS_PROCESSED_NON_TOP_LEVEL_ARR[*]}" ]; then
+    printf "%s\n" "${!TARGET_PLUGIN_DEPS_PROCESSED_NON_TOP_LEVEL_ARR[@]}" | sort > "${TARGET_PLUGIN_DEPS_PROCESSED_NON_TOP_LEVEL}"
+  fi
+  if [ -n "${TARGET_PLUGIN_DEPENDENCY_RESULTS_ARR[*]}" ]; then
+    echo "plugins:" > "${TARGET_PLUGIN_DEPENDENCY_RESULTS}"
+    printf "  - id: %s\n" "${!TARGET_PLUGIN_DEPENDENCY_RESULTS_ARR[@]}" | sort >> "${TARGET_PLUGIN_DEPENDENCY_RESULTS}"
+    # yq -i '.plugins|=sort_by(.id)|... comments=""' "${TARGET_PLUGIN_DEPENDENCY_RESULTS}"
+  fi
 
   info "Processing dependency tree..."
   unset TARGET_PLUGIN_DEPS_PROCESSED_TREE_SINGLE_LINE_ARR
@@ -860,6 +870,8 @@ processAllDeps() {
       echo "${TARGET_PLUGIN_DEPS_PROCESSED_TREE_SINGLE_LINE_ARR_FINISHED[$p]}" >> "$TARGET_PLUGIN_DEPS_PROCESSED_TREE_SINGLE_LINE"
     fi
   done
+  # create if needed
+  touch "$TARGET_PLUGIN_DEPS_PROCESSED_TREE_SINGLE_LINE"
   sort -o "$TARGET_PLUGIN_DEPS_PROCESSED_TREE_SINGLE_LINE" "$TARGET_PLUGIN_DEPS_PROCESSED_TREE_SINGLE_LINE"
 }
 

--- a/tests/complex/expected/plugin-catalog-offline.yaml
+++ b/tests/complex/expected/plugin-catalog-offline.yaml
@@ -10,7 +10,7 @@ configurations:
       ansicolor:
         url: "https://jenkins-updates.cloudbees.com/download/plugins/ansicolor/1.0.2/ansicolor.hpi"
       artifactory:
-        url: "https://jenkins-updates.cloudbees.com/download/plugins/artifactory/3.18.9/artifactory.hpi"
+        url: "https://jenkins-updates.cloudbees.com/download/plugins/artifactory/4.0.0/artifactory.hpi"
       aws-java-sdk:
         url: "https://jenkins-updates.cloudbees.com/download/plugins/aws-java-sdk/1.12.406-374.v4cdf53953691/aws-java-sdk.hpi"
       aws-java-sdk-cloudformation:
@@ -46,7 +46,7 @@ configurations:
       configuration-as-code-groovy:
         url: "https://jenkins-updates.cloudbees.com/download/plugins/configuration-as-code-groovy/1.1/configuration-as-code-groovy.hpi"
       ec2-fleet:
-        url: "https://jenkins-updates.cloudbees.com/download/plugins/ec2-fleet/3.0.0/ec2-fleet.hpi"
+        url: "https://jenkins-updates.cloudbees.com/download/plugins/ec2-fleet/3.1.0/ec2-fleet.hpi"
       envinject:
         url: "https://jenkins-updates.cloudbees.com/download/plugins/envinject/2.908.v66a_774b_31d93/envinject.hpi"
       envinject-api:
@@ -78,7 +78,7 @@ configurations:
       slack:
         url: "https://jenkins-updates.cloudbees.com/download/plugins/slack/664.vc9a_90f8b_c24a_/slack.hpi"
       swarm:
-        url: "https://jenkins-updates.cloudbees.com/download/plugins/swarm/3.40/swarm.hpi"
+        url: "https://jenkins-updates.cloudbees.com/download/plugins/swarm/3.41/swarm.hpi"
       throttle-concurrents:
         url: "https://jenkins-updates.cloudbees.com/download/plugins/throttle-concurrents/2.13/throttle-concurrents.hpi"
       uno-choice:

--- a/tests/complex/expected/plugin-catalog.yaml
+++ b/tests/complex/expected/plugin-catalog.yaml
@@ -10,7 +10,7 @@ configurations:
       ansicolor:
         version: "1.0.2"
       artifactory:
-        version: "3.18.9"
+        version: "4.0.0"
       aws-java-sdk:
         version: "1.12.406-374.v4cdf53953691"
       aws-java-sdk-cloudformation:
@@ -46,7 +46,7 @@ configurations:
       configuration-as-code-groovy:
         version: "1.1"
       ec2-fleet:
-        version: "3.0.0"
+        version: "3.1.0"
       envinject:
         version: "2.908.v66a_774b_31d93"
       envinject-api:
@@ -78,7 +78,7 @@ configurations:
       slack:
         version: "664.vc9a_90f8b_c24a_"
       swarm:
-        version: "3.40"
+        version: "3.41"
       throttle-concurrents:
         version: "2.13"
       uno-choice:

--- a/tests/multi-files/expected/plugin-catalog-offline.yaml
+++ b/tests/multi-files/expected/plugin-catalog-offline.yaml
@@ -18,4 +18,4 @@ configurations:
       beer:
         url: "https://jenkins-updates.cloudbees.com/download/plugins/beer/42.v776b_04d96de3/beer.hpi"
       job-dsl:
-        url: "https://jenkins-updates.cloudbees.com/download/plugins/job-dsl/1.85/job-dsl.hpi"
+        url: "https://jenkins-updates.cloudbees.com/download/plugins/job-dsl/1.87/job-dsl.hpi"

--- a/tests/multi-files/expected/plugin-catalog.yaml
+++ b/tests/multi-files/expected/plugin-catalog.yaml
@@ -18,4 +18,4 @@ configurations:
       beer:
         version: "42.v776b_04d96de3"
       job-dsl:
-        version: "1.85"
+        version: "1.87"

--- a/tests/simple-generation-only/expected/plugin-catalog-offline.yaml
+++ b/tests/simple-generation-only/expected/plugin-catalog-offline.yaml
@@ -32,4 +32,4 @@ configurations:
       beer:
         url: "https://jenkins-updates.cloudbees.com/download/plugins/beer/42.v776b_04d96de3/beer.hpi"
       ec2-fleet:
-        url: "https://jenkins-updates.cloudbees.com/download/plugins/ec2-fleet/3.0.0/ec2-fleet.hpi"
+        url: "https://jenkins-updates.cloudbees.com/download/plugins/ec2-fleet/3.1.0/ec2-fleet.hpi"

--- a/tests/simple-generation-only/expected/plugin-catalog.yaml
+++ b/tests/simple-generation-only/expected/plugin-catalog.yaml
@@ -32,4 +32,4 @@ configurations:
       beer:
         version: "42.v776b_04d96de3"
       ec2-fleet:
-        version: "3.0.0"
+        version: "3.1.0"


### PR DESCRIPTION
This PR fixes an edge case where, after calculation, the minimal plugin list is found to be empty.

This could happen if you, for example, specify bootstrap plugins only.

Not really plausible, but who knows what people throw at this tool.
