### PR TITLE
Add optional catalog name, desc, and leading `---`

### DIFF
--- a/tests/complex/expected/plugin-catalog-offline.yaml
+++ b/tests/complex/expected/plugin-catalog-offline.yaml
@@ -1,7 +1,7 @@
 type: "plugin-catalog"
 version: "1"
 name: "my-plugin-catalog"
-displayName: "My Offline Plugin Catalog"
+displayName: "My Plugin Catalog (offline)"
 configurations:
   - description: "These are Non-CAP plugins for version 2.387.3.5"
     prerequisites:

--- a/tests/multi-files/expected/plugin-catalog-offline.yaml
+++ b/tests/multi-files/expected/plugin-catalog-offline.yaml
@@ -1,7 +1,7 @@
 type: "plugin-catalog"
 version: "1"
 name: "my-plugin-catalog"
-displayName: "My Offline Plugin Catalog"
+displayName: "My Plugin Catalog (offline)"
 configurations:
   - description: "These are Non-CAP plugins for version 2.387.3.5"
     prerequisites:

--- a/tests/simple-annotations-override/expected/plugin-catalog-offline.yaml
+++ b/tests/simple-annotations-override/expected/plugin-catalog-offline.yaml
@@ -1,7 +1,7 @@
 type: "plugin-catalog"
 version: "1"
 name: "my-plugin-catalog"
-displayName: "My Offline Plugin Catalog"
+displayName: "My Plugin Catalog (offline)"
 configurations:
   - description: "These are Non-CAP plugins for version 2.387.3.5"
     prerequisites:

--- a/tests/simple-annotations/expected/plugin-catalog-offline.yaml
+++ b/tests/simple-annotations/expected/plugin-catalog-offline.yaml
@@ -1,7 +1,7 @@
 type: "plugin-catalog"
 version: "1"
 name: "my-plugin-catalog"
-displayName: "My Offline Plugin Catalog"
+displayName: "My Plugin Catalog (offline)"
 configurations:
   - description: "These are Non-CAP plugins for version 2.387.3.5"
     prerequisites:

--- a/tests/simple-download/expected/plugin-catalog-offline.yaml
+++ b/tests/simple-download/expected/plugin-catalog-offline.yaml
@@ -1,7 +1,7 @@
 type: "plugin-catalog"
 version: "1"
 name: "my-plugin-catalog"
-displayName: "My Offline Plugin Catalog"
+displayName: "My Plugin Catalog (offline)"
 configurations:
   - description: "These are Non-CAP plugins for version 2.387.3.5"
     prerequisites:

--- a/tests/simple-generation-only/expected/plugin-catalog-offline.yaml
+++ b/tests/simple-generation-only/expected/plugin-catalog-offline.yaml
@@ -1,7 +1,7 @@
 type: "plugin-catalog"
 version: "1"
 name: "my-plugin-catalog"
-displayName: "My Offline Plugin Catalog"
+displayName: "My Plugin Catalog (offline)"
 configurations:
   - description: "These are Non-CAP plugins for version 2.387.3.5"
     prerequisites:

--- a/tests/simple-sha/expected/plugin-catalog-offline.yaml
+++ b/tests/simple-sha/expected/plugin-catalog-offline.yaml
@@ -1,7 +1,7 @@
 type: "plugin-catalog"
 version: "1"
 name: "my-plugin-catalog"
-displayName: "My Offline Plugin Catalog"
+displayName: "My Plugin Catalog (offline)"
 configurations:
   - description: "These are Non-CAP plugins for version 2.387.3.5"
     prerequisites:

--- a/tests/simple/expected/plugin-catalog-offline.yaml
+++ b/tests/simple/expected/plugin-catalog-offline.yaml
@@ -1,7 +1,7 @@
 type: "plugin-catalog"
 version: "1"
 name: "my-plugin-catalog"
-displayName: "My Offline Plugin Catalog"
+displayName: "My Plugin Catalog (offline)"
 configurations:
   - description: "These are Non-CAP plugins for version 2.387.3.5"
     prerequisites:

--- a/utils/generate-effective-bundles.sh
+++ b/utils/generate-effective-bundles.sh
@@ -695,10 +695,27 @@ runPrecommit() {
 
 }
 
+checkForLatestVersion() {
+    local currentTag="${1-}"
+    currentTag="${currentTag//*:/}"
+    local latestVersion=''
+    latestVersion=$(curl -s "https://api.github.com/repos/kyounger/casc-plugin-dependency-calculation/releases/latest" | grep -oE "tag_name\": \"v[0-9]+\.[0-9]+\.[0-9]+\"" | cut -d'"' -f 3)
+    echo "Latest version of configuration-as-code-plugin is $latestVersion"
+    if [ -n "$currentTag" ]; then
+        if [ "$(ver "${latestVersion}")" -gt "$(ver "${currentTag}")" ]; then
+            die "There is a newer version of casc-plugin-dependency-calculation available ($latestVersion). Please upgrade your version '$currentTag'."
+        fi
+    fi
+}
+
 # main
 ACTION="${1:-}"
-echo "Looking for action '$ACTION'"
+debug "Looking for action '$ACTION'"
 case $ACTION in
+    versionCheck)
+        shift
+        checkForLatestVersion "$@"
+        ;;
     pre-commit)
         processVars
         runPrecommit
@@ -741,7 +758,7 @@ case $ACTION in
     NOTE: If your bundles are separated into groups through sub-directories, use the BUNDLE_SUB_DIR environment variable to specify the sub-directory."
         ;;
 esac
-echo "Done"
+debug "Done"
 
 # Example: unique plugins
 #


### PR DESCRIPTION
Added optional:
- PLUGIN\_CATALOG\_NAME
- PLUGIN\_CATALOG\_DESC
- PLUGIN\_CATALOG\_DESC\_OFFLINE
- LEADING\_DOCUMENT\_SEPARATOR # defaults to empty, can set to '---'

Example:

```sh
❯ PLUGIN_CATALOG_NAME=bla \
PLUGIN_CATALOG_DESC=blub \
LEADING_DOCUMENT_SEPARATOR='---' \
./run.sh -f my-plugins-beer.yaml -sA -v 2.387.3.5 \
-F /tmp/blaF.yaml \
-g /tmp/blag.yaml \
-G /tmp/blaG.yaml \
-c /tmp/blac.yaml \
-C /tmp/blaC.yaml
INFO: CI_VERSION set to '2.387.3.5'.
INFO: Setting CACHE_BASE_DIR=/home/sboardwell/Workspace/sboardwell/casc-plugin-dependency-calculation/.cache
INFO: Using the single file 'my-plugins-beer.yaml'.
....
```

or

```sh
❯ PLUGIN_CATALOG_NAME=bla \
PLUGIN_CATALOG_DESC=blub \
LEADING_DOCUMENT_SEPARATOR='---' \
FINAL_TARGET_PLUGIN_YAML_PATH=/tmp/blaF.yaml \
FINAL_TARGET_PLUGIN_YAML_PATH_MINIMAL=/tmp/blag.yaml \
FINAL_TARGET_PLUGIN_YAML_PATH_MINIMAL_GEN=/tmp/blaG.yaml \
FINAL_TARGET_PLUGIN_CATALOG=/tmp/blac.yaml \
FINAL_TARGET_PLUGIN_CATALOG_OFFLINE=/tmp/blaC.yaml \
./run.sh -f my-plugins-beer.yaml -sA -v 2.387.3.5
INFO: CI_VERSION set to '2.387.3.5'.
INFO: Setting CACHE_BASE_DIR=/home/sboardwell/Workspace/sboardwell/casc-plugin-dependency-calculation/.cache
INFO: Using the single file 'my-plugins-beer.yaml'.
...
...
```

Gives you...

```sh
❯ head -v /tmp/blac.yaml /tmp/blaC.yaml /tmp/blaF.yaml /tmp/blag.yaml /tmp/blaG.yaml
==> /tmp/blac.yaml <==
---
type: "plugin-catalog"
version: "1"
name: "bla"
displayName: "blub"
configurations:
  - description: "These are Non-CAP plugins for version 2.387.3.5"
    prerequisites:
      productVersion: "[2.387.3.5]"
    includePlugins:

==> /tmp/blaC.yaml <==
---
type: "plugin-catalog"
version: "1"
name: "bla"
displayName: "blub (offline)"
configurations:
  - description: "These are Non-CAP plugins for version 2.387.3.5"
    prerequisites:
      productVersion: "[2.387.3.5]"
    includePlugins:

==> /tmp/blaF.yaml <==
---
# This file is automatically generated - please do not edit manually.

# Annotations (given as a comment above the plugin in question):
#  tag:custom:version=...    - set a custom version (e.g. 1.0)
#  tag:custom:url=...        - sets a custom url (e.g. https://artifacts.acme.test/my-plugin/1.0/my-plugin.jpi)
#  tag:custom:requires=...   - spaced separated list of required dependencies (e.g. badge envinject)

# Plugin Categories:
#  cap - is this a CAP plugin?

==> /tmp/blag.yaml <==
---
# This file is automatically generated - please do not edit manually.

# Annotations (given as a comment above the plugin in question):
#  tag:custom:version=...    - set a custom version (e.g. 1.0)
#  tag:custom:url=...        - sets a custom url (e.g. https://artifacts.acme.test/my-plugin/1.0/my-plugin.jpi)
#  tag:custom:requires=...   - spaced separated list of required dependencies (e.g. badge envinject)

# Plugin Categories:
#  cap - is this a CAP plugin?

==> /tmp/blaG.yaml <==
---
# This file is automatically generated - please do not edit manually.

# Annotations (given as a comment above the plugin in question):
#  tag:custom:version=...    - set a custom version (e.g. 1.0)
#  tag:custom:url=...        - sets a custom url (e.g. https://artifacts.acme.test/my-plugin/1.0/my-plugin.jpi)
#  tag:custom:requires=...   - spaced separated list of required dependencies (e.g. badge envinject)

# Plugin Categories:
#  cap - is this a CAP plugin?

