### PR TITLE
fix: ensure pre-commit uses args

### DIFF
--- a/utils/generate-effective-bundles.sh
+++ b/utils/generate-effective-bundles.sh
@@ -1020,7 +1020,7 @@ createTestResources() {
 
 runPrecommit() {
     PRE_COMMIT_LOG=/tmp/pre-commit.check-effective-bundles.log
-    $0 generate > "$PRE_COMMIT_LOG" 2>&1
+    generate > "$PRE_COMMIT_LOG" 2>&1
     # if we:
     # - ran without recreating the plugin catalogs (DRY_RUN=1)
     # - find changes to effective plugins directories


### PR DESCRIPTION
running `cascgen pre-commit some-filter/raw-bundles/thing` fails -- imo it should allow args as `cascgen generate` does.

So, here we go.