### PR TITLE
fix: remove all dependent CAP plugins

### DIFF
--- a/tests/complex/expected/plugin-catalog-offline.yaml
+++ b/tests/complex/expected/plugin-catalog-offline.yaml
@@ -10,7 +10,7 @@ configurations:
       ansicolor:
         url: "https://jenkins-updates.cloudbees.com/download/plugins/ansicolor/1.0.2/ansicolor.hpi"
       artifactory:
-        url: "https://jenkins-updates.cloudbees.com/download/plugins/artifactory/4.0.3/artifactory.hpi"
+        url: "https://jenkins-updates.cloudbees.com/download/plugins/artifactory/4.0.5/artifactory.hpi"
       aws-java-sdk:
         url: "https://jenkins-updates.cloudbees.com/download/plugins/aws-java-sdk/1.12.406-374.v4cdf53953691/aws-java-sdk.hpi"
       aws-java-sdk-cloudformation:
@@ -56,7 +56,7 @@ configurations:
       h2-api:
         url: "https://jenkins-updates.cloudbees.com/download/plugins/h2-api/11.1.4.199-12.v9f4244395f7a_/h2-api.hpi"
       hashicorp-vault-plugin:
-        url: "https://jenkins-updates.cloudbees.com/download/plugins/hashicorp-vault-plugin/364.vf5d54b_3dc313/hashicorp-vault-plugin.hpi"
+        url: "https://jenkins-updates.cloudbees.com/download/plugins/hashicorp-vault-plugin/366.v3b_57135510d6/hashicorp-vault-plugin.hpi"
       ivy:
         url: "https://jenkins-updates.cloudbees.com/download/plugins/ivy/2.4/ivy.hpi"
       job-dsl:
@@ -74,7 +74,7 @@ configurations:
       resource-disposer:
         url: "https://jenkins-updates.cloudbees.com/download/plugins/resource-disposer/0.23/resource-disposer.hpi"
       robot:
-        url: "https://jenkins-updates.cloudbees.com/download/plugins/robot/3.5.0/robot.hpi"
+        url: "https://jenkins-updates.cloudbees.com/download/plugins/robot/3.5.1/robot.hpi"
       slack:
         url: "https://jenkins-updates.cloudbees.com/download/plugins/slack/664.vc9a_90f8b_c24a_/slack.hpi"
       swarm:

--- a/tests/complex/expected/plugin-catalog.yaml
+++ b/tests/complex/expected/plugin-catalog.yaml
@@ -10,7 +10,7 @@ configurations:
       ansicolor:
         version: "1.0.2"
       artifactory:
-        version: "4.0.3"
+        version: "4.0.5"
       aws-java-sdk:
         version: "1.12.406-374.v4cdf53953691"
       aws-java-sdk-cloudformation:
@@ -56,7 +56,7 @@ configurations:
       h2-api:
         version: "11.1.4.199-12.v9f4244395f7a_"
       hashicorp-vault-plugin:
-        version: "364.vf5d54b_3dc313"
+        version: "366.v3b_57135510d6"
       ivy:
         version: "2.4"
       job-dsl:
@@ -74,7 +74,7 @@ configurations:
       resource-disposer:
         version: "0.23"
       robot:
-        version: "3.5.0"
+        version: "3.5.1"
       slack:
         version: "664.vc9a_90f8b_c24a_"
       swarm:


### PR DESCRIPTION
This PR now removes all CAP plugins if a parent is found in the list.

Previously only direct parents were checked in the final cleanup.

To test, use the plugins.yaml and run `./run.sh -f plugins.yaml -s`

```yaml
plugins:
- id: branch-api
- id: job-dsl
- id: blueocean
```

Now the `branch-api` (a deep dependency of the `blueocean` plugin) will also be removed from the `plugins-minimal.yaml`.

This was not happening in the previus version since only direct parents were checked, for example if the `pipeline-maven` plugin was included.

Commits

- fix: remove CAP plugins when parent in list
- chore: update tests
