### PR TITLE
feat: Add custom header to plugin catalog as well

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1137,6 +1137,8 @@ Plugin Categories:
   fi
   if [ "${PLUGIN_YAML_INCLUDE_HEADER}" -eq 1 ]; then
     HEADER="$HEADER" yq -i '. head_comment=strenv(HEADER)' "$TARGET_PLUGINS_YAML"
+    HEADER="$HEADER" yq -i '. head_comment=strenv(HEADER)' "$TARGET_PLUGIN_CATALOG"
+    HEADER="$HEADER" yq -i '. head_comment=strenv(HEADER)' "$TARGET_PLUGIN_CATALOG_OFFLINE"
   fi
 
   # Plugin comments...


### PR DESCRIPTION
This PR adds the custom header to all produced yaml files.

Example:

```sh
PLUGIN_YAML_CUSTOM_HEADER="# Copyright Steve 2024
# All files have this
" cascdeps -f plugins-source.yaml -sA
INFO: CI_VERSION not set. Determining latest version...
INFO: CI_VERSION set to '2.440.2.1'.
...
...
```

Will give...

```sh
❯ head -n 5 target/2.440.2.1/mm/plugin-catalog-offline.yaml target/2.440.2.1/mm/plugin-catalog.yaml target/2.440.2.1/mm/plugins.yaml target/2.440.2.1/mm/plugins-minimal.yaml target/2.440.2.1/mm/plugins-minimal-for-generation-only.yaml 
==> target/2.440.2.1/mm/plugin-catalog-offline.yaml <==
# Copyright Steve 2024
# All files have this

type: "plugin-catalog"
version: "1"
name: "my-plugin-catalog"

==> target/2.440.2.1/mm/plugin-catalog.yaml <==
# Copyright Steve 2024
# All files have this

type: "plugin-catalog"
version: "1"
name: "my-plugin-catalog"

==> target/2.440.2.1/mm/plugins.yaml <==
# Copyright Steve 2024
# All files have this

plugins:
  - id: blueocean # cap src
  - id: branch-api # cap dep

==> target/2.440.2.1/mm/plugins-minimal.yaml <==
# Copyright Steve 2024
# All files have this

plugins:
  - id: blueocean # cap src
  - id: job-dsl # 3rd src

==> target/2.440.2.1/mm/plugins-minimal-for-generation-only.yaml <==
# Copyright Steve 2024
# All files have this

plugins:
  - id: blueocean # cap src
  - id: job-dsl # 3rd src
```
